### PR TITLE
Use ASGI 3.0 interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ codecov
 isort
 pytest
 pytest-cov
-starlette
+starlette==0.12.0b3  # Unpin once 0.12 is released

--- a/sentry_asgi/middleware.py
+++ b/sentry_asgi/middleware.py
@@ -9,20 +9,14 @@ class SentryMiddleware:
     def __init__(self, app):
         self.app = app
 
-    def __call__(self, scope):
-        return functools.partial(self.asgi, asgi_scope=scope)
-
-    async def asgi(self, receive, send, asgi_scope):
+    async def __call__(self, scope, receive, send):
         hub = sentry_sdk.Hub.current
         with sentry_sdk.Hub(hub) as hub:
             with hub.configure_scope() as sentry_scope:
-                processor = functools.partial(
-                    self.event_processor, asgi_scope=asgi_scope
-                )
+                processor = functools.partial(self.event_processor, asgi_scope=scope)
                 sentry_scope.add_event_processor(processor)
                 try:
-                    inner = self.app(asgi_scope)
-                    await inner(receive, send)
+                    await self.app(scope, receive, send)
                 except Exception as exc:
                     hub.capture_exception(exc)
                     raise exc from None


### PR DESCRIPTION
This PR upgrades sentry-asgi to ASGI 3.0's single-call app interface.

I believe this should be released quickly to have a working Sentry integration ready when Starlette and other frameworks start shipping releases using ASGI 3.0.

I'll leave any README updates to you, as I'm sure @tomchristie has a better understanding of ASGI 3.0 and the implications of upgrading to it than I have.